### PR TITLE
Load dev pkg for external

### DIFF
--- a/src/deliver/solve.py
+++ b/src/deliver/solve.py
@@ -62,6 +62,11 @@ class Required(object):
                   PackageInstaller.StatusMapStr[self.status])
 
 
+def join_variant_request(request, variant_index):
+    index = "" if variant_index is None else ("[%d]" % variant_index)
+    return str(request) + index
+
+
 variant_index_regex = re.compile(r"(.+)\[([0-9]+)]")
 
 
@@ -360,11 +365,15 @@ class RequestSolver(object):
             try:
                 context = self._resolve_build_context(variant_requires)
             except (PackageFamilyNotFoundError, PackageNotFoundError) as e:
+                print("[X] Error on resolving build-time context of '%s'"
+                      % join_variant_request(request, variant.index))
                 print(e)
                 requested.status = self.ResolveFailed
 
             else:
                 if not context.success:
+                    print("[!] Problems on resolving build-time context of '%s'"
+                          % join_variant_request(request, variant.index))
                     context.print_info()
                     requested.status = self.ResolveFailed
                 else:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -229,21 +229,7 @@ class TestManifest(TestBase):
         self.assertEqual(self.installer.Ready, foo_request.status)
 
     def test_resolve_with_external(self):
-        # TODO: External package (installed but not in developer repository)
-        #   is being required by current installation requested package, and
-        #   although external package's requirement does exists in developer
-        #   repository, the installation still cannot be resolved.
-        #   -
-        #   This is because the external package's requirement is not been
-        #   evaluated and the loader is in lazy load mode by default.
-        #   -
-        #   To solve this, parse package name from PackageNotFoundError and
-        #   try find it from developer repository, re-resolve build context
-        #   if found, or print the error as warning.
-        #   -
-        #   Try counting error for same missing package, and print warning
-        #   only once.
-        #
+        # the external one, not exists in developer package repository
         installed_repo = DeveloperRepository(self.install_path)
         installed_repo.add("ext", requires=["bar"])
 
@@ -254,7 +240,13 @@ class TestManifest(TestBase):
 
         self.installer.resolve("foo")
         manifest = self.installer.manifest()
-        self.assertEqual(manifest[0].status, self.installer.ResolveFailed)
+
+        self.assertEqual(6, len(manifest))
+        for req in manifest:
+            if req.name == "ext":
+                self.assertEqual(self.installer.External, req.status)
+            else:
+                self.assertEqual(self.installer.Ready, req.status)
 
     def test_buildtime_variants(self):
         @early()


### PR DESCRIPTION
A developer package may have requirement that is not in current *recipe repositories* but only in installed, which makes it an external one.

And the dependencies of external package will not like any other developer package that gets dependencies loaded before resolving build time context.

So we compensate that when `PackageFamilyNotFoundError` is raised, parse missing package name from the error message and retry once.

A well managed *recipe repositories* should not have this happened, but just for the convenience.
