### PR TITLE
continue iter package when hitting bad one

### DIFF
--- a/src/deliver/repository.py
+++ b/src/deliver/repository.py
@@ -330,9 +330,9 @@ class DevPkgRepo(Repo):
             yield family.name  # package dir name
 
     def _generate_dev_packages(self, family):
-        for package in family.iter_packages():
+        for package in family.iter_packages():  # package order is random
             if not package.uri:  # A sub-dir in Family dir without package file
-                return
+                continue
 
             filepath = package.uri
             dirpath = os.path.dirname(filepath)


### PR DESCRIPTION
Previously, developer package loading process *stopped* when encountering a bad package (sub-dir in Family dir without package file), and a weird bug pops up.

Because `family.iter_packages` iterates packages in random order, the bad package breaks the process randomly, in result, we gets random package load count.

Just continue the process solve the issue.