### PR TITLE
Fix variant resolved status

### DIFF
--- a/src/deliver/solve.py
+++ b/src/deliver/solve.py
@@ -353,13 +353,13 @@ class RequestSolver(object):
             if variant_index is not None and variant_index != variant.index:
                 continue
 
-            if status == self.Ready and i_van is not None:
-                status = self.Installed
-
             requested = Required.get(name, variant.index)
             requested.source = source
             requested.status = status
             requested.ver_tag = variant.parent.data.get("__ver_tag__")
+
+            if status == self.Ready and i_van is not None:
+                requested.status = self.Installed
 
             if self.__depended:
                 requested.depended.append(self.__depended)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -350,6 +350,21 @@ class TestManifest(TestBase):
         manifest = self.installer.manifest()
         self.assertEqual(2, len(manifest))
 
+    def test_variants_installed_separately(self):
+        self.dev_repo.add("foo", version="1", build_command=False)
+        self.dev_repo.add("foo", version="2", build_command=False)
+        self.dev_repo.add("bar", version="5", build_command=False,
+                          variants=[["foo-1"], ["foo-2"]])
+
+        self.installer.resolve("foo-1", "foo-2", "bar[0]")
+        self._run_install()
+
+        self.installer.resolve("bar")
+        manifest = self.installer.manifest()
+
+        self.assertEqual("bar-5", manifest[-1].name)
+        self.assertEqual(self.installer.Ready, manifest[-1].status)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

Say we have a package that looks like this :
```python
# package.py
name = "foo"
variants = [
    ["python-2.7"],
    ["python-3.7"],
]
```
And only install the first variant :
```shell
$ rez-deliver foo[0]
```
After awhile, you decide to install all the variants :
```shell
$ rez-deliver foo
```
But you may find `deliver` told you that all variants have been installed.
```shell
Following packages will be deployed:
----------------------------------------------------------------------
 foo[0]    | (installed)
 foo[1]    | (installed)
Do you want to continue ? [Y/n]
```
Which is not true.

## Fix
Change the solver to avoid variant's `status` gets shadowed by the previous one.

